### PR TITLE
Format void tag

### DIFF
--- a/gazpacho/utils.py
+++ b/gazpacho/utils.py
@@ -65,7 +65,7 @@ def format(html: str, fail: bool = False) -> str:
         self_closing_html = sub(VOID_TAGS_RE, fr'\1 {placeholder}=""/\3', html)
         dom = string_to_dom(self_closing_html)
         ugly = dom.toprettyxml(indent="  ")
-        split = list(map(lambda x: x.replace(f' {placeholder}=""/', ''), filter(lambda x: len(x.strip()), ugly.split("\n"))))[1:]
+        split = [line.replace(f' {placeholder}=""/', '') for line in ugly.split("\n") if len(line.strip())][1:]
         html = "\n".join(split)
     except ExpatError as error:
         if fail:

--- a/gazpacho/utils.py
+++ b/gazpacho/utils.py
@@ -1,9 +1,9 @@
 from random import choice
 from re import sub
 from string import ascii_letters
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, Callable
 from urllib.parse import quote, urlsplit, urlunsplit
-from xml.dom.minidom import parseString as string_to_dom
+from xml.dom.minidom import Document, parseString as string_to_dom
 from xml.parsers.expat import ExpatError
 
 ParserAttrs = List[Tuple[str, Optional[str]]]
@@ -57,15 +57,11 @@ def format(html: str, fail: bool = False) -> str:
     ```
     """
     try:
-        # attribute placeholder as a mark to transform back
-        while True:        
-            placeholder = ''.join(choice(ascii_letters) for i in range(8))        
-            if placeholder not in html:
-                break
-        self_closing_html = sub(VOID_TAGS_RE, fr'\1 {placeholder}=""/\3', html)
-        dom = string_to_dom(self_closing_html)
+        dom, back_transform = _string_to_dom(html)
         ugly = dom.toprettyxml(indent="  ")
-        split = [line.replace(f' {placeholder}=""/', '') for line in ugly.split("\n") if len(line.strip())][1:]
+        if back_transform:
+            ugly = back_transform(ugly)
+        split = list(filter(lambda x: len(x.strip()), ugly.split("\n")))[1:]
         html = "\n".join(split)
     except ExpatError as error:
         if fail:
@@ -174,3 +170,17 @@ def recover_html_and_attrs(
     else:
         html = f"<{tag}{attrs_str}>"
     return html, attrs_dict
+
+
+def _string_to_dom(html: str) -> Tuple[Document, Union[Callable[[str], str], None]]:
+    try:
+        return string_to_dom(html), None
+    except ExpatError:
+        # try to transform void tags to self-closing tags and try again
+        # attribute placeholder as a mark to transform back
+        while True:
+            placeholder = ''.join(choice(ascii_letters) for i in range(8))
+            if placeholder not in html:
+                break
+        self_closing_html = sub(VOID_TAGS_RE, fr'\1 {placeholder}=""/\3', html)
+        return string_to_dom(self_closing_html), lambda s: s.replace(f' {placeholder}=""/', '')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,6 +81,17 @@ def test_format_fail():
         format(html, fail=True)
 
 
+def test_format_void_tag():
+    html = """<body><img src="self-closing.png"/><img src="void.png"></body>"""
+    assert format(html) == """<body>\n  <img src="self-closing.png"/>\n  <img src="void.png">\n</body>"""
+
+
+def test_format_invalid_void_tag_fail():
+    html = """<body><xxx src="void.png"></body>"""
+    with pytest.raises(ExpatError):
+        format(html, fail=True)
+
+
 def test_sanitize_weird_characters():
     url = sanitize("https://httpbin.org/anything/drãke")
     assert url == "https://httpbin.org/anything/dr%C3%A3ke"


### PR DESCRIPTION
## Issue
Fixes https://github.com/maxhumber/gazpacho/issues/26

## Problem
string_to_dom is unable to handle void tags

## Solution
transform void tags to self-closing tags and transform back

## Changes
- Add test cases
- Use regex to find void tags
- Use a special random attribute as a marker to know which void tags have been transformed.