### PR TITLE
Initialize .text on Soup creation

### DIFF
--- a/gazpacho/soup.py
+++ b/gazpacho/soup.py
@@ -56,7 +56,7 @@ class Soup(HTMLParser):
         self._html = "" if not html else html
         self.tag: str = ""
         self.attrs: Optional[Dict[str, Any]] = None
-        self.text: str = ""
+        self.text: str = self.unescape(self.strip(html)) if html else ""
 
     def __repr__(self) -> str:
         return self.html


### PR DESCRIPTION
Uses `strip` to extract text from non-empty html.

Resolves #28 