### PR TITLE
Add wheel publishing to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ deploy:
   password: $PYPI_PASSWORD
   on:
     tags: true
+  distributions: "sdist bdist_wheel"


### PR DESCRIPTION
This will also publish wheel file to PyPI when package is deployed using Travis CI. You can check [Travis CI docs](https://docs.travis-ci.com/user/deployment/pypi/#uploading-different-distributions) for more details.

This is pure-Python package, so wheel will be compatible with all Python versions. However, wheel is still useful, because it enables a bit faster and safer installation (`setup.py` isn't executed on installation). Some environments might also have `setup.py` installation disabled, so this will make sure the package will work there as well.