### PR TITLE
Potential Code Refactor

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/gazpacho/get.py
+++ b/gazpacho/get.py
@@ -24,8 +24,8 @@ def random_ua(string):
 
 def get(
     url: str,
-    params: Dict[str, Any] = {},
-    headers: Dict[str, Any] = {},
+    params: Dict[str, Any] = None,
+    headers: Dict[str, Any] = None,
 ) -> Union[str, Dict[str, Any]]:
     """Retrive url contents
 
@@ -41,6 +41,10 @@ def get(
     get('https://httpbin.org/anything', {'soup': 'gazpacho'})
     ```
     """
+    if params is None:
+        params = {}
+    if headers is None:
+        headers = {}
     url = sanitize(url)
     opener = build_opener()
     opener.addheaders = list({**{"User-Agent": random_ua(USER_AGENT)}, **headers}.items())

--- a/gazpacho/soup.py
+++ b/gazpacho/soup.py
@@ -187,13 +187,11 @@ class Soup(HTMLParser):
         if not groups:
             if mode in all:
                 return []
-            else:
-                return None
+            return None
         elif mode in automatic:
             if len(groups) == 1:
                 return groups[0]
-            else:
-                return groups
+            return groups
         elif mode in all:
             return groups
         elif mode in first:

--- a/gazpacho/soup.py
+++ b/gazpacho/soup.py
@@ -76,12 +76,16 @@ class Soup(HTMLParser):
     def get(
         cls,
         url: str,
-        params: Dict[str, Any] = {},
-        headers: Dict[str, Any] = {},
+        params: Dict[str, Any] = None,
+        headers: Dict[str, Any] = None,
     ) -> "Soup":
         """\
         Intialize with gazpacho.get
         """
+        if params is None:
+            params = {}
+        if headers is None:
+            headers = {}
         html = get(url, params, headers)
         if not isinstance(html, str):
             raise Exception(f"Unable to retrieve contents from {url}")

--- a/gazpacho/utils.py
+++ b/gazpacho/utils.py
@@ -113,12 +113,10 @@ def match(a: Dict[Any, Any], b: Dict[Any, Any], *, partial: bool = False) -> boo
         if not partial:
             if lhs == rhs:
                 continue
-            else:
-                return False
+            return False
         if lhs in rhs:
             continue
-        else:
-            return False
+        return False
     return True
 
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -12,7 +12,8 @@ def test_get(create_mock_responses):
     url = "https://en.wikipedia.org/wiki/Gazpacho"
 
     content = get(url)
-    assert title in content
+    if title not in content:
+        raise AssertionError
 
 
 def test_get_invalid_content_type(create_mock_responses):
@@ -30,7 +31,8 @@ def test_get_headers(create_mock_responses):
     url = "https://httpbin.org/headers"
 
     content = get(url, headers=headers)
-    assert UA == content["headers"]["User-Agent"]
+    if UA != content["headers"]["User-Agent"]:
+        raise AssertionError
 
 
 def test_get_multiple_headers(create_mock_responses):
@@ -41,7 +43,8 @@ def test_get_multiple_headers(create_mock_responses):
     content = get(url, headers=headers)
     headers_set = set(headers.values())
     response_set = set(content["headers"].values())
-    assert headers_set.intersection(response_set) == {"Mozilla/5.0", "gzip"}
+    if headers_set.intersection(response_set) != {"Mozilla/5.0", "gzip"}:
+        raise AssertionError
 
 
 def test_get_params(create_mock_responses):
@@ -50,7 +53,8 @@ def test_get_params(create_mock_responses):
     url = "https://httpbin.org/anything"
 
     content = get(url, params)
-    assert params == content["args"]
+    if params != content["args"]:
+        raise AssertionError
 
 
 def test_HTTPError_404(create_mock_responses):

--- a/tests/test_soup.py
+++ b/tests/test_soup.py
@@ -104,7 +104,8 @@ def test_find_inner_text():
     html = """<p>&pound;600m</p>"""
     soup = Soup(html)
     result = soup.text
-    assert result == "£600m"
+    if result != "£600m":
+        raise AssertionError
 
 
 def test_find_inner_text_for_nested_html():
@@ -117,103 +118,119 @@ def test_find_inner_text_for_nested_html():
             """
     soup = Soup(html)
     result = soup.text
-    assert result == "£600m"
+    if result != "£600m":
+        raise AssertionError
     
 
 def test_find(fake_html_1):
     soup = Soup(fake_html_1)
     result = soup.find("span")
-    assert str(result) == "<span>Hi</span>"
+    if str(result) != "<span>Hi</span>":
+        raise AssertionError
 
 
 def test_find_first(fake_html_1):
     soup = Soup(fake_html_1)
     result = soup.find("p", mode="first")
-    assert str(result) == "<p>'IDK!'</p>"
+    if str(result) != "<p>'IDK!'</p>":
+        raise AssertionError
 
 
 def test_find_with_attrs(fake_html_1):
     soup = Soup(fake_html_1)
     result = soup.find("p", {"id": "blarg"})
-    assert str(result) == '<p id="blarg">Try for 2</p>'
+    if str(result) != '<p id="blarg">Try for 2</p>':
+        raise AssertionError
 
 
 def test_find_multiple(fake_html_1):
     soup = Soup(fake_html_1)
     result = soup.find("div", {"class": "baz"})
-    assert len(result) == 2
-    assert str(result[1]) == '<div class="baz">Oh No!</div>'
+    if len(result) != 2:
+        raise AssertionError
+    if str(result[1]) != '<div class="baz">Oh No!</div>':
+        raise AssertionError
 
 
 def test_find_text(fake_html_1):
     soup = Soup(fake_html_1)
     result = soup.find("p", {"id": "blarg"})
-    assert result.text == "Try for 2"
+    if result.text != "Try for 2":
+        raise AssertionError
 
 
 def test_find_nested_groups(fake_html_2):
     soup = Soup(fake_html_2)
     results = soup.find("div", {"class": "foo"})
-    assert len(results) == 2
+    if len(results) != 2:
+        raise AssertionError
 
 
 def test_find_partial_false(fake_html_2):
     soup = Soup(fake_html_2)
     result = soup.find("div", {"class": "foo"}, partial=False, mode="all")
-    assert len(result) == 1
+    if len(result) != 1:
+        raise AssertionError
 
 
 def test_find_nested_empty_tag(fake_html_3):
     soup = Soup(fake_html_3)
     result = soup.find("a", {"class": "foo"})
-    assert len(result) == 2
+    if len(result) != 2:
+        raise AssertionError
 
 
 def test_find_mutliple_imgs(fake_html_3):
     soup = Soup(fake_html_3)
     middle = soup.find("img")[1]
-    assert middle.attrs["src"] == "bye.jpg"
+    if middle.attrs["src"] != "bye.jpg":
+        raise AssertionError
 
 
 def test_strip(fake_html_4):
     soup = Soup(fake_html_4)
     result = soup.strip()
-    assert (
-        result == "I like soup and I really like cold soup I guess hot soup is okay too"
-    )
+    if (
+        result != "I like soup and I really like cold soup I guess hot soup is okay too"
+    ):
+        raise AssertionError
 
 
 def test_strip_keep_whitespace(fake_html_4):
     soup = Soup(fake_html_4)
     result = soup.strip(whitespace=False)
-    assert (
-        result
-        == "    \n      I like soup and I really like cold soup\n      I guess hot soup is okay too\n    \n    "
-    )
+    if (
+        result != "    \n      I like soup and I really like cold soup\n      I guess hot soup is okay too\n    \n    "
+    ):
+        raise AssertionError
 
 
 def test_find_no_match_first(fake_html_1):
     soup = Soup(fake_html_1)
     result = soup.find("a", mode="first")
-    assert result is None
+    if result is not None:
+        raise AssertionError
 
 
 def test_find_no_match_all(fake_html_1):
     soup = Soup(fake_html_1)
     result = soup.find("a", mode="all")
-    assert result == []
+    if result != []:
+        raise AssertionError
 
 
 def test_find_no_match_auto(fake_html_1):
     soup = Soup(fake_html_1)
     result = soup.find("a", mode="auto")
-    assert result is None
+    if result is not None:
+        raise AssertionError
 
 
 def test_malformed_void_tags(fake_html_5):
     soup = Soup(fake_html_5)
     result = soup.find("img")
-    assert len(result) == 3
+    if len(result) != 3:
+        raise AssertionError
 
 
 def test_remove_tags_warning(fake_html_4):
@@ -230,7 +247,8 @@ def test_find_strict(fake_html_2):
 
 def test_soup_get_cls_method():
     soup = Soup.get("www.google.com")
-    assert "<!doctype html>" in str(soup).lower()
+    if "<!doctype html>" not in str(soup).lower():
+        raise AssertionError
 
 
 def test_bad_mode_argument(fake_html_1):
@@ -242,21 +260,25 @@ def test_bad_mode_argument(fake_html_1):
 def test_undocumented_random_mode(fake_html_6):
     soup = Soup(fake_html_6)
     pset = set([soup.find("p", mode="random").attrs["id"] for _ in range(10)])
-    assert len(pset) > 1
+    if len(pset) <= 1:
+        raise AssertionError
 
 
 def test_undocumented_last_mode(fake_html_6):
     soup = Soup(fake_html_6)
-    assert soup.find("p", mode="last").text == "G"
+    if soup.find("p", mode="last").text != "G":
+        raise AssertionError
 
 
 def test_html_format_in_soup():
     html = """<ul><li>Item</li><li>Item</li></ul>"""
     soup = Soup(html)
-    assert soup.html == "<ul>\n  <li>Item</li>\n  <li>Item</li>\n</ul>"
+    if soup.html != "<ul>\n  <li>Item</li>\n  <li>Item</li>\n</ul>":
+        raise AssertionError
 
 
 def test_bad_html_not_formatted_in_soup():
     html = """<div><ul><li>Item</li><li>Item</li></ul>"""
     soup = Soup(html)
-    assert soup.html == html
+    if soup.html != html:
+        raise AssertionError

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,83 +8,97 @@ from gazpacho.utils import format, match, recover_html_and_attrs, sanitize
 def test_attr_match():
     a = {"foo": "bar"}
     b = {"foo": "bar"}
-    assert match(a, b)
+    if not match(a, b):
+        raise AssertionError
 
 
 def test_attr_match_query_empty():
     a = {}
     b = {"foo": "bar"}
-    assert match(a, b)
+    if not match(a, b):
+        raise AssertionError
 
 
 def test_match_empty_empty():
     a = {}
     b = {}
-    assert match(a, b)
+    if not match(a, b):
+        raise AssertionError
 
 
 def test_match_empty_attrs_fail():
     a = {"foo": "bar"}
     b = {}
-    assert not match(a, b)
+    if match(a, b):
+        raise AssertionError
 
 
 def test_match_partial():
     a = {"foo": "bar"}
     b = {"foo": "bar baz"}
-    assert match(a, b, partial=True)
+    if not match(a, b, partial=True):
+        raise AssertionError
 
 
 def test_match_multiple():
     a = {"foo1": "bar1", "foo2": "bar2"}
     b = {"foo1": "bar1", "foo2": "bar2"}
-    assert match(a, b)
+    if not match(a, b):
+        raise AssertionError
 
 
 def test_match_multiple_fail():
     a = {"foo1": "bar1", "foo2": "bar2"}
     b = {"foo1": "bar1", "foo2": "baz1"}
-    assert not match(a, b)
+    if match(a, b):
+        raise AssertionError
 
 
 def test_match_query_too_much_fail():
     a = {"foo1": "bar1 baz1", "foo2": "bar2"}
     b = {"foo1": "bar1", "foo2": "bar2"}
-    assert not match(a, b)
+    if match(a, b):
+        raise AssertionError
 
 
 def test_match_multiple_partial():
     a = {"foo1": "bar1", "foo2": "bar2"}
     b = {"foo1": "bar1 baz1", "foo2": "bar2"}
-    assert match(a, b, partial=True)
+    if not match(a, b, partial=True):
+        raise AssertionError
 
 
 def test_multiple_partial_fail():
     a = {"foo1": "bar1", "foo2": "bar2"}
     b = {"foo1": "bar1 baz1", "foo2": "bar2"}
-    assert not match(a, b, partial=False)
+    if match(a, b, partial=False):
+        raise AssertionError
 
 
 def test_recover_html_and_attrs():
     html, attrs = recover_html_and_attrs("img", [("src", "example.png")])
-    assert html == '<img src="example.png">' and attrs == {"src": "example.png"}
+    if not (html == '<img src="example.png">' and attrs == {"src": "example.png"}):
+        raise AssertionError
 
 
 def test_format():
     html = """<ul><li>Item</li><li>Item</li></ul>"""
-    assert format(html) == "<ul>\n  <li>Item</li>\n  <li>Item</li>\n</ul>"
+    if format(html) != "<ul>\n  <li>Item</li>\n  <li>Item</li>\n</ul>":
+        raise AssertionError
 
 
 def test_format_whitespace():
     html = """<ul>                <li>Item</li           ><li>Item</li>
 
     </ul       >"""
-    assert format(html) == "<ul>\n  <li>Item</li>\n  <li>Item</li>\n</ul>"
+    if format(html) != "<ul>\n  <li>Item</li>\n  <li>Item</li>\n</ul>":
+        raise AssertionError
 
 
 def test_format_whitespace_inside_tag():
     html = """<ul><li>Item</li><li>I t e m</li></ul>"""
-    assert format(html) == "<ul>\n  <li>Item</li>\n  <li>I t e m</li>\n</ul>"
+    if format(html) != "<ul>\n  <li>Item</li>\n  <li>I t e m</li>\n</ul>":
+        raise AssertionError
 
 
 def test_format_fail_missing_closing():
@@ -113,10 +127,10 @@ def test_format_trailing_text():
 
 def test_format_void_tag():
     html = """<body><img src="self-closing.png"/><img src="void.png"></body>"""
-    assert (
-        format(html)
-        == """<body>\n  <img src="self-closing.png">\n  <img src="void.png">\n</body>"""
-    )
+    if (
+        format(html) != """<body>\n  <img src="self-closing.png">\n  <img src="void.png">\n</body>"""
+    ):
+        raise AssertionError
 
 
 def test_format_invalid_void_tag_fail():
@@ -127,9 +141,11 @@ def test_format_invalid_void_tag_fail():
 
 def test_sanitize_weird_characters():
     url = sanitize("https://httpbin.org/anything/drãke")
-    assert url == "https://httpbin.org/anything/dr%C3%A3ke"
+    if url != "https://httpbin.org/anything/dr%C3%A3ke":
+        raise AssertionError
 
 
 def test_sanitize_missing_protocol():
     url = sanitize("gazpacho.xyz")
-    assert url == "http://gazpacho.xyz"
+    if url != "http://gazpacho.xyz":
+        raise AssertionError


### PR DESCRIPTION
## Description
<!-- A short description about what you have changed / added. If this closes an issue, please write Closes #1234 (replace 1234 with the issue number)-->

This PR includes:
- Fix dangerous default argument 
- Remove assert statement from non-test files. Use of `raise AssertionError` instead of bare `assert`s
  - Usage of `assert` statement in application logic is discouraged. assert is removed with compiling to optimized byte code (python -o producing *.pyo files).
- Refactor unnecessary `else` / `elif` when `if` block has a `continue` or `return`statement
  - `return` statement causes the control flow to be disrupted, making the `else` / `elif` block here unnecessary. This doesn't mean you can not use it, but it is recommended to refactor this for better readability.

## More Information
<!-- Describe in detail about how you have solved the problem, and maybe add some screenshots -->
